### PR TITLE
Update to nerves_system_br v0.13.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule NervesSystemRpi3.Mixfile do
 
   defp deps do
     [{:nerves, "~> 0.5.1", runtime: false },
-     {:nerves_system_br, "~> 0.10.1", runtime: false },
+     {:nerves_system_br, "~> 0.13.0", runtime: false },
      {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 0.10.0", runtime: false}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"distillery": {:hex, :distillery, "1.4.0", "d633cd322c8efa0428082b00b7f902daf8caa166d45f9022bbc19a896d2e1e56", [:mix], [], "hexpm"},
+%{"distillery": {:hex, :distillery, "1.4.1", "546d851bf27ae8fe0727e10e4fc4e146ad836eecee138263a60431e688044ed3", [:mix], [], "hexpm"},
   "nerves": {:hex, :nerves, "0.5.2", "ce89fb603ae58076fc48ff88323eafe71d302d031393c78a3883002c8d3176ba", [:mix], [{:distillery, "~> 1.2", [hex: :distillery, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_system_br": {:hex, :nerves_system_br, "0.10.1", "c3a40fcca99a46e485aec22f3a55d09dbc97dbe7902874ce794778625a336730", [:mix], [], "hexpm"},
+  "nerves_system_br": {:hex, :nerves_system_br, "0.13.0", "9205f582747204baf917b2e822756665c81d5225b9caae5ab12f9250b4c17a36", [:mix], [], "hexpm"},
   "nerves_toolchain_arm_unknown_linux_gnueabihf": {:hex, :nerves_toolchain_arm_unknown_linux_gnueabihf, "0.10.0", "18200c6cc3fcda1cbe263b7f7d50ff05db495b881ade9436cd1667b3e8e62429", [:mix], [{:nerves, "~> 0.4", [hex: :nerves, repo: "hexpm", optional: false]}, {:nerves_toolchain_ctng, "~> 0.9", [hex: :nerves_toolchain_ctng, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "0.9.0", "825b2b5bbacc3ad20c8513baafd44978616d5b451e6e052cdb727be81e7cdcac", [:mix], [], "hexpm"}}


### PR DESCRIPTION
This pulls in Erlang/OTP 20, important updates to erlinit and fwup,
and many updates to Linux programs from Buildroot updates.